### PR TITLE
Skip "Copyright holder corporate name"="UC Regents" column for rights status Copyright UC Regents when presented.

### DIFF
--- a/src/edu/ucsd/library/xdre/tab/RecordUtil.java
+++ b/src/edu/ucsd/library/xdre/tab/RecordUtil.java
@@ -18,8 +18,8 @@ import org.dom4j.QName;
 public class RecordUtil
 {
     // private type values
-    private static String copyrightPublic  = "Public domain";
-    private static String copyrightRegents = "Copyright UC Regents";
+    public static String copyrightPublic  = "Public domain";
+    public static String copyrightRegents = "Copyright UC Regents";
     private static String copyrightPerson = "Copyrighted (Person)";
     private static String copyrightCorporate = "Copyrighted (Corporate)";
     private static String copyrightOther = "Copyrighted (Other)";

--- a/src/edu/ucsd/library/xdre/tab/TabularRecord.java
+++ b/src/edu/ucsd/library/xdre/tab/TabularRecord.java
@@ -401,6 +401,13 @@ public class TabularRecord implements Record
         {
         	RecordUtil.addRights(e.getDocument(), null, null, copyrightStatus, copyrightJurisdiction, null, null,
         			null, accessOverride, beginDate, endDate);
+        	
+        	// Ingore column "copyright holder corporate name" = "UC Regents" for Copyright Status = "Copyright UC Regents" when presented
+        	if (!StringUtils.isBlank(copyrightStatus) && copyrightStatus.equalsIgnoreCase(RecordUtil.copyrightRegents)){
+	        	String rightsHolders = data.get("copyright holder corporate name");
+	        	if (!StringUtils.isBlank(rightsHolders) && rightsHolders.trim().equalsIgnoreCase("UC Regents"))
+	        		data.remove("copyright holder corporate name");
+        	}
         }
         
         // rights holder (special case of subject name) /////////////////////////////////


### PR DESCRIPTION
Excel Input Stream support to ignore "Copyright holder corporate name"="UC Regents" column. See https://lib-jira.ucsd.edu:8443/browse/DI-22.