### PR TITLE
Updated for better supporting multiple related resource with separator '@' and bugs fixing for the Excel input stream.

### DIFF
--- a/src/edu/ucsd/library/xdre/tab/ExcelSource.java
+++ b/src/edu/ucsd/library/xdre/tab/ExcelSource.java
@@ -81,6 +81,7 @@ public class ExcelSource implements RecordSource
                 headers.add( firstRow.getCell(i).getStringCellValue().toLowerCase() );
             }
             currRow++;
+            cache = parseRow( currRow );
         }
     }
 
@@ -153,6 +154,7 @@ public class ExcelSource implements RecordSource
                 Cell cell = row.getCell(i);
                 if ( cell != null )
                 {
+                	cell.setCellType(Cell.CELL_TYPE_STRING);
                     value = cell.toString();
                 }
             }

--- a/src/edu/ucsd/library/xdre/tab/TabularRecord.java
+++ b/src/edu/ucsd/library/xdre/tab/TabularRecord.java
@@ -33,6 +33,7 @@ public class TabularRecord implements Record
     public static final String OBJECT_COMPONENT_TYPE = "object/component";
     public static final String COMPONENT = "component";
     public static final String DELIMITER = "|";
+    public static final String DELIMITER_CELL = "@";
     public static final String[] ACCEPTED_DATE_FORMATS = {"yyyy-MM-dd", "yyyy-MM", "yyyy"};
     private static DateFormat[] dateFormats = {new SimpleDateFormat(ACCEPTED_DATE_FORMATS[0]), 
     	new SimpleDateFormat(ACCEPTED_DATE_FORMATS[1]), new SimpleDateFormat(ACCEPTED_DATE_FORMATS[2])};
@@ -340,11 +341,11 @@ public class TabularRecord implements Record
             if ( key.startsWith("related resource") )
             {
                 String values = data.get( key );
-
-            	if ( pop(values) ) {
-            		values = values.trim();
-	                String[] elemValues = values.split("\\|\\|");
-	            	if (elemValues.length == 1 && !(values.startsWith("||") || values.endsWith("||")) || elemValues.length > 2) {
+                for ( String value : split(values) )
+                {
+	                String[] elemValues = value.split("\\" + DELIMITER_CELL);
+	            	if (elemValues.length == 1 && !(values.startsWith(DELIMITER_CELL) || values.endsWith(DELIMITER_CELL))) {
+	            		elemValues = value.split(" " + DELIMITER_CELL + " ");
 	            		throw new Exception("Invalid Related Resource value in record " + recordID() + ": \"" + values + "\"");
 	            	}
 	            	


### PR DESCRIPTION
Reopen https://lib-jira.ucsd.edu:8443/browse/DM-70 for multiple related resource mapping with separator '@', along with a couple of bug fixing for Excel source reading.