### PR TITLE
Sort to ensure that the zip file for the bib/Roger records is at the second position

### DIFF
--- a/src/edu/ucsd/library/xdre/web/CollectionOperationController.java
+++ b/src/edu/ucsd/library/xdre/web/CollectionOperationController.java
@@ -13,6 +13,7 @@ import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -1200,6 +1201,7 @@ public class CollectionOperationController implements Controller {
 				getRogerFile(fileList, bib, file);
 			}
 		}
+		Collections.sort(fileList);
 		return fileList;
 	}
 	


### PR DESCRIPTION
Fixed the bug that listed the pdf and zip files for bib/Roger record in unexpected order:
See https://lib-jira.ucsd.edu:8443/browse/DM-77.