### PR TITLE
Disabled creating derivatives for documents basing on its file use property

### DIFF
--- a/src/edu/ucsd/library/xdre/collection/CollectionHandler.java
+++ b/src/edu/ucsd/library/xdre/collection/CollectionHandler.java
@@ -637,8 +637,8 @@ public abstract class CollectionHandler implements ProcessHandler {
 	public boolean isDocument(String fileName, String use){
 		fileName = fileName.toLowerCase();
 		String mimeType = DAMSClient.getMimeType(fileName);
-		if((use!=null && use.toLowerCase().startsWith("document")) || 
-				mimeType.indexOf("pdf")>=0 || fileName.endsWith(".pdf"))
+		if(/*(use!=null && use.toLowerCase().startsWith("document")) || */
+				mimeType.toLowerCase().indexOf("pdf")>=0 || fileName.toLowerCase().endsWith(".pdf"))
 			return true;
 		else
 			return false;

--- a/src/edu/ucsd/library/xdre/collection/CollectionHandler.java
+++ b/src/edu/ucsd/library/xdre/collection/CollectionHandler.java
@@ -637,8 +637,7 @@ public abstract class CollectionHandler implements ProcessHandler {
 	public boolean isDocument(String fileName, String use){
 		fileName = fileName.toLowerCase();
 		String mimeType = DAMSClient.getMimeType(fileName);
-		if(/*(use!=null && use.toLowerCase().startsWith("document")) || */
-				mimeType.toLowerCase().indexOf("pdf")>=0 || fileName.toLowerCase().endsWith(".pdf"))
+		if( mimeType.toLowerCase().indexOf("pdf")>=0 || fileName.toLowerCase().endsWith(".pdf"))
 			return true;
 		else
 			return false;


### PR DESCRIPTION
Disabled creating derivatives for documents basing on its file use property to avoid getting the derivatives creation failed error from non-PDF documents: see https://lib-jira.ucsd.edu:8443/browse/DM-77.