### PR TITLE
Fixes rename servlet name and report title for collection items hits/downloads statistics. damspas#265

### DIFF
--- a/WebContent/WEB-INF/damsmanager-servlet.xml
+++ b/WebContent/WEB-INF/damsmanager-servlet.xml
@@ -81,7 +81,7 @@
 	<bean name="/statsCollections.do" class="edu.ucsd.library.xdre.web.StatsCollectionsAccessController"></bean>
 	<bean name="/statsRdcpUsage.do" class="edu.ucsd.library.xdre.web.StatsRdcpUsageController"></bean>
 	<bean name="/statsRdcpDownload.do" class="edu.ucsd.library.xdre.web.StatsRdcpDownloadController"></bean>
-	<bean name="/statsCollection.do" class="edu.ucsd.library.xdre.web.StatsCollectionItemsController"></bean>
+	<bean name="/statsCollectionObjects.do" class="edu.ucsd.library.xdre.web.StatsCollectionItemsController"></bean>
 
 	<bean id="force-init" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
   		<property name="staticMethod"><value>edu.ucsd.library.xdre.utils.DAMSRoutineManager.startRoutine</value></property>

--- a/WebContent/WEB-INF/jsp/stats.jsp
+++ b/WebContent/WEB-INF/jsp/stats.jsp
@@ -103,8 +103,8 @@
 			<c:if test="${model.isCurator}">
 				<li><div class="item"><a href="statsRdcpUsage.do">RDCP Objects Views by Month</a></div></li>
 				<li><div class="item"><a href="statsRdcpDownload.do">RDCP File Download By Month</a></div></li>
-				<li><div class="item"><a href="statsCollection.do">Collection Hits by Month</a></div></li>
-				<li><div class="item"><a href="statsCollection.do?type=downloads">Collection Downloads By Month</a></div></li>
+				<li><div class="item"><a href="statsCollectionObjects.do">Object/Collection Hits by Month</a></div></li>
+				<li><div class="item"><a href="statsCollectionObjects.do?type=downloads">Object/Collection Downloads by Month</a></div></li>
 			</c:if>
 		</ul>
 	</div>

--- a/WebContent/WEB-INF/jsp/statsCollectionObjects.jsp
+++ b/WebContent/WEB-INF/jsp/statsCollectionObjects.jsp
@@ -50,7 +50,7 @@
 			</tbody>
 		</table>
 		<div class="export">
-			<a href="/damsmanager/statsCollection.do?type=${model.type}&start=${model.start}&export">
+			<a href="/damsmanager/statsCollectionObjects.do?type=${model.type}&start=${model.start}&export">
 				<img src="images/excel-icon.png" border="0" width="16px" />
 				<span style="display:table-cell;vertical-align:top;font-size:11ps;font-weight:bold;">&nbsp;Export CSV</span></a>
 		</div>

--- a/WebContent/WEB-INF/web.xml
+++ b/WebContent/WEB-INF/web.xml
@@ -135,7 +135,7 @@
             <url-pattern>/statusItems.do</url-pattern>
             <url-pattern>/statsRdcpUsage.do</url-pattern>
             <url-pattern>/statsRdcpDownload.do</url-pattern>
-            <url-pattern>/statsCollection.do</url-pattern>
+            <url-pattern>/statsCollectionObjects.do</url-pattern>
         </web-resource-collection>
         <auth-constraint>
             <role-name>dams-curator</role-name>

--- a/src/edu/ucsd/library/xdre/web/StatsCollectionItemsController.java
+++ b/src/edu/ucsd/library/xdre/web/StatsCollectionItemsController.java
@@ -58,6 +58,11 @@ public class StatsCollectionItemsController implements Controller {
 		SimpleDateFormat dbFormat = null;
 
 		DAMSClient damsClient = null;
+
+		String statsTitle = "Object/Collection Hits by Month";
+		if (StringUtils.isNotBlank(type) && type.equalsIgnoreCase("downloads"))
+			statsTitle = "Object/Collection Downloads by Month";
+
 		try {
 			
 			dbFormat = new SimpleDateFormat(Statistics.DATE_FORMAT);
@@ -89,7 +94,7 @@ public class StatsCollectionItemsController implements Controller {
 				strBuf = new StringBuilder();
 				for(StatsCollectionItemSummary statsItemSum : statsItemSums) {
 					if (count == 0) {
-						strBuf.append("Collection Hits by Month\n");
+						strBuf.append(statsTitle + "\n");
 						strBuf.append("Collection,ARK");
 						for (String period : statsItemSum.getPeriods()) {
 							strBuf.append("," + Statistics.escapeCsv(period));
@@ -123,16 +128,12 @@ public class StatsCollectionItemsController implements Controller {
 		}
 
 		if(export == null) {
-			String statsTitle = "Collection Hits by Month";
-			if (StringUtils.isNotBlank(type) && type.equalsIgnoreCase("downloads"))
-				statsTitle = "Collection Downloads by Month";
-
-				model.put("message", message);
+			model.put("message", message);
 			model.put("statsTitle", statsTitle);
 			model.put("type", (StringUtils.isBlank(type)?"hits":type));
 			model.put("start", dbFormat.format(sCal.getTime()));
 
-			return new ModelAndView("statsCollection", "model", model);
+			return new ModelAndView("statsCollectionObjects", "model", model);
 		}else{
 			if(message != null && message.length() > 0)
 				strBuf.append(message);


### PR DESCRIPTION
Related: https://github.com/ucsdlib/damspas/issues/265
Suggested by Gabriela, I am creating the PR to rename the servlet to statsCollectionObjects.do and the report title to "Object/Collection Hits by Month" and "Object/Collection Downloads by Month" for collection items hits/downloads statistics.
