### PR TITLE
Closes #145 - Fixed the error in parsing the filename for file download stats.

### DIFF
--- a/src/edu/ucsd/library/xdre/statistic/analyzer/DAMStatistic.java
+++ b/src/edu/ucsd/library/xdre/statistic/analyzer/DAMStatistic.java
@@ -222,7 +222,8 @@ public class DAMStatistic extends Statistics{
 		}
 
 		// differentiate the counts for file download and object access/hits
-		String fileSubfix = fileName.substring(fileName.lastIndexOf("_"));
+		int file_name_idx = fileName.lastIndexOf("_");
+		String fileSubfix = file_name_idx >= 0 ? fileName.substring(file_name_idx) : "";
 
 		if (uri.indexOf("/download") > 0) {
 			fileDownload(objCounter, fileName);


### PR DESCRIPTION
Fixes #145

Fixed the error in parsing the filename for file download.

@ucsdlib/developers - please review
