### PR TITLE
Fixes #241 - Updated for MARC and METS/MODS subject conversion with FAST headings

### DIFF
--- a/WebContent/files/dams42json.xsl
+++ b/WebContent/files/dams42json.xsl
@@ -171,7 +171,7 @@
         <xsl:variable name="hasExactExternalAuthority" select="mads:hasExactExternalAuthority/@rdf:resource" />
         <xsl:variable name="fastHeadings">
           <xsl:choose>
-            <xsl:when test="starts-with($hasExactExternalAuthority, 'http://id.worldcat.org/fast/')"> FAST</xsl:when>
+            <xsl:when test="contains($hasExactExternalAuthority, 'id.worldcat.org/fast/')"> FAST</xsl:when>
             <xsl:otherwise></xsl:otherwise>
           </xsl:choose>
         </xsl:variable>

--- a/WebContent/files/dams42json.xsl
+++ b/WebContent/files/dams42json.xsl
@@ -168,14 +168,28 @@
 
     <xsl:template name="subject">
         <xsl:param name="columnName"/>
+        <xsl:variable name="hasExactExternalAuthority" select="mads:hasExactExternalAuthority/@rdf:resource" />
+        <xsl:variable name="fastHeadings">
+          <xsl:choose>
+            <xsl:when test="starts-with($hasExactExternalAuthority, 'http://id.worldcat.org/fast/')"> FAST</xsl:when>
+            <xsl:otherwise></xsl:otherwise>
+          </xsl:choose>
+        </xsl:variable>
         <xsl:call-template name="appendJsonObject">
-           <xsl:with-param name="key"><xsl:value-of select="$columnName"/></xsl:with-param>
+           <xsl:with-param name="key"><xsl:value-of select="$columnName"/><xsl:value-of select="$fastHeadings"/></xsl:with-param>
            <xsl:with-param name="val"><xsl:value-of select="mads:authoritativeLabel"/></xsl:with-param>
         </xsl:call-template>
     </xsl:template>
 
     <xsl:template name="complexSubject" match="mads:ComplexSubject">
         <xsl:variable name="subjectName" select="local-name(mads:componentList/*[1])"/>
+        <xsl:variable name="hasExactExternalAuthority" select="mads:componentList/*[1]/mads:hasExactExternalAuthority/@rdf:resource" />
+        <xsl:variable name="fastHeadings">
+          <xsl:choose>
+            <xsl:when test="starts-with($hasExactExternalAuthority, 'http://id.worldcat.org/fast/')"> FAST</xsl:when>
+            <xsl:otherwise></xsl:otherwise>
+          </xsl:choose>
+        </xsl:variable>
         <xsl:variable name="columnName">
             <xsl:choose>
                 <xsl:when test="$subjectName = 'ConferenceName'">conference name</xsl:when>

--- a/WebContent/files/mets2dams.xsl
+++ b/WebContent/files/mets2dams.xsl
@@ -911,7 +911,6 @@
     </xsl:element>
   </xsl:template>
   <xsl:template match="mods:mods/mods:subject">
-    <xsl:if test="//mods:subject[translate(@authority, $lowercase, $uppercase)='FAST'] and translate(@authority, $lowercase, $uppercase)='FAST'">
     <xsl:choose>
       <xsl:when test="count(*) &gt; 1">
         <xsl:variable name="predicateName">
@@ -1030,7 +1029,6 @@
         <xsl:apply-templates/>
       </xsl:otherwise>
     </xsl:choose>
-    </xsl:if>
   </xsl:template>
   <xsl:template match="mods:mods/mods:genre">
     <xsl:if test="//mods:mods/mods:genre[translate(@authority, $lowercase, $uppercase)='FAST'] and translate(@authority, $lowercase, $uppercase)='FAST'">


### PR DESCRIPTION
Fixes #241

#### Local Checklist
- [ ] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
Updated to support MARC to CSV and METS/MODS to CSV with FAST headings for subjects. Column names of subjects with FAST headings (mads:hasExactExternalAuthority) that has a URI starting with http://id.worldcat.org/fast/ will append text "FAST".

##### Why are we doing this? Any context of related work?
References #241, #116

@ucsdlib/developers - please review
