### PR TITLE
Fixes #251 - Ignore control characters to avoid the com.hp.hpl.jena.shared.CannotEncodeCharacterException

### DIFF
--- a/src/edu/ucsd/library/xdre/collection/CollectionHandler.java
+++ b/src/edu/ucsd/library/xdre/collection/CollectionHandler.java
@@ -95,6 +95,8 @@ public abstract class CollectionHandler implements ProcessHandler {
 	protected int itemsCount = 0; //Total number of items in the collection/batch
 	protected List<String> solrFailed = new ArrayList<String>();
 	
+	protected StringBuilder warnings = new StringBuilder();
+
 	/**
 	 * Empty constructor
 	 */
@@ -157,6 +159,14 @@ public abstract class CollectionHandler implements ProcessHandler {
 			itemsCount = items.size();
 			collectionTitle = collectionsMap.get(collectionId);
 		}
+	}
+
+	public void addWarning(String warning) {
+		warnings.append(warning);
+ 	}
+
+	public String getWarnings() {
+		return warnings.toString();
 	}
 
 	/**

--- a/src/edu/ucsd/library/xdre/imports/RDFDAMS4ImportTsHandler.java
+++ b/src/edu/ucsd/library/xdre/imports/RDFDAMS4ImportTsHandler.java
@@ -1420,7 +1420,12 @@ public class RDFDAMS4ImportTsHandler extends MetadataImportHandler{
 		if(filesIngested.length() > 0){
 			log.info("\nThe following files are ingested successfully: \n" + filesIngested.toString());
 		}
-		
+
+		if(warnings.length() > 0) {
+		    exeReport.append("\nWarning(s):\n");
+		    exeReport.append(warnings.toString());
+		}
+
 		log("log", "\n______________________________________________________________________________________________");
 		String exeInfo = exeReport.toString();
 		logMessage(exeInfo);

--- a/src/edu/ucsd/library/xdre/tab/TabularRecord.java
+++ b/src/edu/ucsd/library/xdre/tab/TabularRecord.java
@@ -606,42 +606,46 @@ public class TabularRecord implements Record
     {
         return ( s != null && !s.trim().equals("") );
     }
-    private static List<String> split( String s )
+    public static List<String> split( String s )
     {
         ArrayList<String> list = new ArrayList<>();
         if ( pop(s) )
         {
-            if ( s.indexOf(DELIMITER) != -1 )
+            StringBuilder sb = new StringBuilder();
+            boolean escaped = false;
+            for( char ch : s.toCharArray() )
             {
-                StringBuilder sb = new StringBuilder();
-                boolean escaped = false;
-                for( char ch : s.toCharArray() )
+                if( escaped )
                 {
-                    if( escaped )
-                    { 
-                        sb.append( ch );
-                        escaped = false;
-                    }
-                    else if ( ch == ESCAPE_CHAR )
-                    {
-                        escaped = true;
-                    }
-                    else if ( ch == DELIMITER )
-                    {
-                        list.add( sb.toString().trim() );
-                        sb.setLength( 0 );
-                    }
-                    else
+                    if ( ch == DELIMITER )
                     {
                         sb.append( ch );
                     }
-                }
+                    else if ( !(Character.isISOControl(ESCAPE_CHAR + ch) || Character.isISOControl(ch)) )
+                    {
+                        sb.append( ESCAPE_CHAR + ch );
+                    }
 
-                list.add( sb.toString().trim() );
+                    escaped = false;
+                }
+                else if ( ch == ESCAPE_CHAR )
+                {
+                    escaped = true;
+                }
+                else if ( ch == DELIMITER )
+                {
+                    list.add( sb.toString().trim() );
+                    sb.setLength( 0 );
+                }
+                else if ( !Character.isISOControl(ch) )
+                {
+                    sb.append( ch );
+                }
             }
-            else
+
+            if ( sb.length() > 0 )
             {
-                list.add( s.trim() );
+                list.add( sb.toString().trim() );
             }
         }
         return list;

--- a/src/edu/ucsd/library/xdre/tab/TabularRecord.java
+++ b/src/edu/ucsd/library/xdre/tab/TabularRecord.java
@@ -9,6 +9,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.dom4j.Branch;
 import org.dom4j.Document;
 import org.dom4j.DocumentFactory;
@@ -617,14 +618,7 @@ public class TabularRecord implements Record
             {
                 if( escaped )
                 {
-                    if ( ch == DELIMITER )
-                    {
-                        sb.append( ch );
-                    }
-                    else if ( !(Character.isISOControl(ESCAPE_CHAR + ch) || Character.isISOControl(ch)) )
-                    {
-                        sb.append( ESCAPE_CHAR + ch );
-                    }
+                    handleEscapedCharacter( sb, ch, false );
 
                     escaped = false;
                 }
@@ -650,7 +644,37 @@ public class TabularRecord implements Record
         }
         return list;
     }
-    
+
+    /**
+     * Handle escaped character. Control character could be ignored or replaced
+     * @param sb StringBuilder the character to be attached
+     * @param ch char the escaped Character
+     * @param replaceChar flag to replace the Character
+     * @return boolean flag indicating that the char is replaced or not
+     */
+    public static boolean handleEscapedCharacter(StringBuilder sb, char ch, boolean replaceChar)
+    {
+        boolean replaced = false;
+        if ( ch == DELIMITER )
+        {
+            sb.append( ch );
+        }
+        else if ( !(Character.isISOControl(ESCAPE_CHAR + ch) || Character.isISOControl(ch)) )
+        {
+            sb.append( ESCAPE_CHAR + "" + ch );
+        }
+        else if ( replaceChar )
+        {
+            // replace control character with symbol [character name]
+            replaced = true;
+            if ( Character.isISOControl(ch) )
+                sb.append( TabularRecord.ESCAPE_CHAR + "" + Character.getName(ch) );
+            else
+                sb.append( "[" + Character.getName( StringEscapeUtils.unescapeJava( TabularRecord.ESCAPE_CHAR + "" + ch ).charAt(0) ) + "]" );
+        }
+        return replaced;
+    }
+
     private static void testDateValue ( String objectID, String dateValue, String dateType ) throws ParseException 
     {
     	if(pop( dateValue )) {

--- a/test/edu/ucsd/library/xdre/tab/ExcelSourceTest.java
+++ b/test/edu/ucsd/library/xdre/tab/ExcelSourceTest.java
@@ -1,0 +1,29 @@
+package edu.ucsd.library.xdre.tab;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Test methods for ExcelSource class
+ * @author lsitu
+ *
+ */
+public class ExcelSourceTest {
+
+    @Test
+    public void testReplaceControlChars() {
+        String val = "Test control character\3.\\3";
+
+        String result = ExcelSource.replaceControlChars(val);
+        assertEquals("Value doesn't match!", "Test control character[END OF TEXT].[END OF TEXT]", result);
+    }
+
+    @Test
+    public void testReplaceControlCharsWithNoControlCharacters() {
+        String val = "Test Çatalhöyük \u00c7 \\t \\r \\n control character.";
+
+        String result = ExcelSource.replaceControlChars(val);
+        assertEquals("Value is not null!", null, result);
+    }
+}

--- a/test/edu/ucsd/library/xdre/tab/TabularRecordTest.java
+++ b/test/edu/ucsd/library/xdre/tab/TabularRecordTest.java
@@ -23,6 +23,14 @@ public class TabularRecordTest {
     }
 
     @Test
+    public void testSplitValueWithWithSpecialCharacters() {
+        String val = "Test Çatalhöyük \u00c7 \\t \\r \\n \".";
+
+        List<String> result = TabularRecord.split(val);
+        assertEquals("Value with special characters doesn't match!", "Test Çatalhöyük \u00c7 \\t \\r \\n \".", result.get(0));
+    }
+
+    @Test
     public void testSplitValueWithPipeEscaped() {
         String val = "Test value 1 \\| Test value 2.";
 

--- a/test/edu/ucsd/library/xdre/tab/TabularRecordTest.java
+++ b/test/edu/ucsd/library/xdre/tab/TabularRecordTest.java
@@ -1,0 +1,43 @@
+package edu.ucsd.library.xdre.tab;
+
+import static edu.ucsd.library.xdre.tab.TabularRecord.DELIMITER;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Test methods for TabularRecord class
+ * @author lsitu
+ *
+ */
+public class TabularRecordTest {
+
+    @Test
+    public void testSplitValueWithControlCharacters() {
+        String val = "Test control character\3.\\3";
+
+        List<String> result = TabularRecord.split(val);
+        assertEquals("Value doesn't match!", "Test control character.", result.get(0));
+    }
+
+    @Test
+    public void testSplitValueWithPipeEscaped() {
+        String val = "Test value 1 \\| Test value 2.";
+
+        List<String> result = TabularRecord.split(val);
+        assertEquals("Values size doesn't match!", 1, result.size());
+        assertEquals("Character Pipe (|) isn't escaped correctly!", "Test value 1 | Test value 2.", result.get(0));
+    }
+
+    @Test
+    public void testSplitMultipleValuesWithControlCharacters() {
+        String val = "Test value 1\3. " + DELIMITER  + " Test value 2.\\3";
+
+        List<String> result = TabularRecord.split(val);
+        assertEquals("Values size doesn't match!", 2, result.size());
+        assertEquals("Value 1 doesn't match!", "Test value 1.", result.get(0));
+        assertEquals("Value 2 doesn't match!", "Test value 2.", result.get(1));
+    }
+}


### PR DESCRIPTION
Fixes #251

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
 Ignore control characters during importing objects from Excel source to avoid the com.hp.hpl.jena.shared.CannotEncodeCharacterException while retrieving the object RDF that contains control characters. 

##### Why are we doing this? Any context of related work?
References #250, #251

@ucsdlib/developers - please review
