### PR TITLE
Fixes #251 - Retain LF and CR control characters.

### DIFF
--- a/src/edu/ucsd/library/xdre/tab/ExcelSource.java
+++ b/src/edu/ucsd/library/xdre/tab/ExcelSource.java
@@ -374,7 +374,7 @@ public class ExcelSource implements RecordSource
             {
                 escaped = true;
             }
-            else if ( Character.isISOControl(ch) )
+            else if ( Character.isISOControl(ch) && !TabularRecord.RETAIN_CONTROL_CHAR_LIST.contains(ch) )
             {
                 // report control character and replace it with [character name]
                 controlCharsFound = true;

--- a/src/edu/ucsd/library/xdre/tab/TabularRecord.java
+++ b/src/edu/ucsd/library/xdre/tab/TabularRecord.java
@@ -4,6 +4,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -27,6 +28,9 @@ import org.dom4j.QName;
 **/
 public class TabularRecord implements Record
 {
+    public static final Character[] RETAIN_CONTROL_CHARS = {10, 13};
+    public static List<Character> RETAIN_CONTROL_CHAR_LIST = Arrays.asList(RETAIN_CONTROL_CHARS);
+
     public static final String OBJECT_ID = "object unique id";
     public static final String OBJECT_COMPONENT_TYPE = "level";
     public static final String COMPONENT = "component";
@@ -37,7 +41,7 @@ public class TabularRecord implements Record
     public static final String DELIMITER_LANG_ELEMENT = "-";
     public static final String[] ACCEPTED_DATE_FORMATS = {"yyyy-MM-dd", "yyyy-MM", "yyyy"};
     private static DateFormat[] dateFormats = {new SimpleDateFormat(ACCEPTED_DATE_FORMATS[0]), 
-    	new SimpleDateFormat(ACCEPTED_DATE_FORMATS[1]), new SimpleDateFormat(ACCEPTED_DATE_FORMATS[2])};
+        new SimpleDateFormat(ACCEPTED_DATE_FORMATS[1]), new SimpleDateFormat(ACCEPTED_DATE_FORMATS[2])};
 
     // namespaces
     private static final Namespace rdfNS  = new Namespace(
@@ -631,7 +635,7 @@ public class TabularRecord implements Record
                     list.add( sb.toString().trim() );
                     sb.setLength( 0 );
                 }
-                else if ( !Character.isISOControl(ch) )
+                else if ( !Character.isISOControl(ch) || RETAIN_CONTROL_CHAR_LIST.contains(ch) )
                 {
                     sb.append( ch );
                 }
@@ -655,11 +659,12 @@ public class TabularRecord implements Record
     public static boolean handleEscapedCharacter(StringBuilder sb, char ch, boolean replaceChar)
     {
         boolean replaced = false;
+        boolean isControlChar = Character.isISOControl(ESCAPE_CHAR + ch) || Character.isISOControl(ch);
         if ( ch == DELIMITER )
         {
             sb.append( ch );
         }
-        else if ( !(Character.isISOControl(ESCAPE_CHAR + ch) || Character.isISOControl(ch)) )
+        else if ( !isControlChar || RETAIN_CONTROL_CHAR_LIST.contains(ch) )
         {
             sb.append( ESCAPE_CHAR + "" + ch );
         }

--- a/test/edu/ucsd/library/xdre/tab/TabularRecordTest.java
+++ b/test/edu/ucsd/library/xdre/tab/TabularRecordTest.java
@@ -29,6 +29,19 @@ public class TabularRecordTest {
     }
 
     @Test
+    public void testSplitValueWithRetainedCRLF() {
+        char lf = (char)10;
+        char cr = (char)13;
+        String val = "Test CR/LF control character." + cr + lf + "Another paragraph.";
+
+        List<String> result = TabularRecord.split(val);
+        assertEquals("line feed (lf)", Character.getName(lf).toLowerCase());
+        assertEquals("carriage return (cr)", Character.getName(cr).toLowerCase());
+        assertEquals("Value with chars CR/LF doesn't match!", "Test CR/LF control character." + cr + lf +
+                "Another paragraph.", result.get(0));
+    }
+
+    @Test
     public void testSplitValueWithWithSpecialCharacters() {
         String val = "Test Çatalhöyük \u00c7 \\t \\r \\n \".";
 
@@ -78,5 +91,29 @@ public class TabularRecordTest {
             String id = node.selectSingleNode("rdf:value").getText();
             assertTrue("Identifier value doesn't match!", ids.contains(id));
         }
+    }
+
+    public void testSplitMultipleValuesWithNoControlCharacters() {
+        String val = "Test value 1." + DELIMITER  + "Test value 2." + DELIMITER  + "Test value 3.";
+
+        List<String> result = TabularRecord.split(val);
+        assertEquals("Values size doesn't match!", 3, result.size());
+        assertEquals("Value 1 doesn't match!", "Test value 1.", result.get(0));
+        assertEquals("Value 2 doesn't match!", "Test value 2.", result.get(1));
+        assertEquals("Value 3 doesn't match!", "Test value 3.", result.get(2));
+    }
+
+    @Test
+    public void testSplitMultipleValuesWithLineFeedAndAnchors() {
+        char lf = (char)10;
+        String val = "Test value 1 "+ lf + " <a href=\"http:\\example.com\"></a>" + DELIMITER  
+                + "Test value 2 \\"+ lf + " <a href=\"http:\\example.com\"></a>" + DELIMITER
+                + "Test value 3 "+ lf + " <a href=\"http:\\example.com\"></a>";
+
+        List<String> result = TabularRecord.split(val);
+        assertEquals("Values size doesn't match!", 3, result.size());
+        assertEquals("Value 1 doesn't match!", "Test value 1 "+ lf + " <a href=\"http:\\example.com\"></a>", result.get(0));
+        assertEquals("Value 2 doesn't match!", "Test value 2 \\"+ lf + " <a href=\"http:\\example.com\"></a>", result.get(1));
+        assertEquals("Value 3 doesn't match!", "Test value 3 "+ lf + " <a href=\"http:\\example.com\"></a>", result.get(2));
     }
 }


### PR DESCRIPTION
Fixes #251 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
Don't ignore control characters Line Feed and Carriage Return.

##### Why are we doing this? Any context of related work?
References #251

@ucsdlib/developers - please review
