### PR TITLE
Fixes #258 - Enable multiple values support for header Identifier:identifier

### DIFF
--- a/src/edu/ucsd/library/xdre/tab/TabularRecord.java
+++ b/src/edu/ucsd/library/xdre/tab/TabularRecord.java
@@ -259,8 +259,8 @@ public class TabularRecord implements Record
             String key = it.next();
             if ( key.startsWith("identifier:") )
             {
-                String value = data.get( key );
-                if ( pop(value) )
+                String values = data.get( key );
+                for ( String value : split(values) )
                 {
                     Element e2 = addElement( e, "note", damsNS, "Note", damsNS );
                     addTextElement( e2, "type", damsNS, "identifier" );

--- a/test/edu/ucsd/library/xdre/tab/TabularRecordTest.java
+++ b/test/edu/ucsd/library/xdre/tab/TabularRecordTest.java
@@ -2,9 +2,15 @@ package edu.ucsd.library.xdre.tab;
 
 import static edu.ucsd.library.xdre.tab.TabularRecord.DELIMITER;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.dom4j.Document;
+import org.dom4j.Node;
 import org.junit.Test;
 
 /**
@@ -47,5 +53,30 @@ public class TabularRecordTest {
         assertEquals("Values size doesn't match!", 2, result.size());
         assertEquals("Value 1 doesn't match!", "Test value 1.", result.get(0));
         assertEquals("Value 2 doesn't match!", "Test value 2.", result.get(1));
+    }
+
+    @Test
+    public void testMutipleValuesforIdentifierNote() throws Exception {
+        String idValues = "id 1" + DELIMITER + "id2" + DELIMITER + "id3";
+
+        // Initiate tabular data with multiple Identifier:identifier values delimited by | character
+        Map<String, String> data = new HashMap<>();
+        data.put("object unique id", "object1");
+        data.put("level", "object");
+        data.put("title", "Test object");
+        data.put("identifier:identifier", idValues);
+
+        // Build the dams4 RDF/XML
+        TabularRecord testObject = new TabularRecord(data);
+        Document doc = testObject.toRDFXML();
+
+        List<String> ids = Arrays.asList(idValues.split("\\|"));
+
+        List<Node> nodes = doc.selectNodes("//dams:Note[dams:type='identifier']");
+        assertEquals("The size of the identifier note doesn't match!", 3, nodes.size());
+        for (Node node : nodes) {
+            String id = node.selectSingleNode("rdf:value").getText();
+            assertTrue("Identifier value doesn't match!", ids.contains(id));
+        }
     }
 }


### PR DESCRIPTION
Fixes #258

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
Added multiple values support for Identifier:identifier field.

##### Why are we doing this? Any context of related work?
References #251, 258

@ucsdlib/developers - please review
