### PR TITLE
Fixes #279 - Rename the title for orphans in collections report statistics

### DIFF
--- a/src/edu/ucsd/library/xdre/web/StatsCollectionsReportController.java
+++ b/src/edu/ucsd/library/xdre/web/StatsCollectionsReportController.java
@@ -169,6 +169,11 @@ public class StatsCollectionsReportController implements Controller {
 			for(Iterator<String> uit=unitsRecordsMap.keySet().iterator(); uit.hasNext();){
 				colId = uit.next();
 				colTitle = unitsMap.get(colId);
+				if (colTitle.contains("Research Data")) {
+					colTitle = "Research Data Collections";
+				}
+				colTitle += " Orphans";
+
 				Set<String> uRecords = unitsRecordsMap.get(colId);
 				List<String> items = new ArrayList<String>();
 				items.addAll(uRecords);


### PR DESCRIPTION
Fixes #279

#### Local Checklist
- [ ] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
Rename the title for orphans in collections report statistics to Library Digital Collections Orphans and Research Data Collections Orphans.

##### Why are we doing this? Any context of related work?
References #279

@ucsdlib/developers - please review
