### PR TITLE
Fixes #314 - Disabled CIL ingest that is on hold for release 2.71

### DIFF
--- a/src/edu/ucsd/library/xdre/utils/DAMSRoutineManager.java
+++ b/src/edu/ucsd/library/xdre/utils/DAMSRoutineManager.java
@@ -42,9 +42,9 @@ public class DAMSRoutineManager{
 		timer.schedule(new StatisticsTask(), calendar.getTime());
 
 		// CIL harvesting process
-		calendar.add(Calendar.HOUR_OF_DAY, 3);
-		Date cilHarvestingTime = calendar.getTime();
-		timer.scheduleAtFixedRate(new CILHarvestingTask(), cilHarvestingTime, 1000*60*60*24);
+		// calendar.add(Calendar.HOUR_OF_DAY, 3);
+		// Date cilHarvestingTime = calendar.getTime();
+		// timer.scheduleAtFixedRate(new CILHarvestingTask(), cilHarvestingTime, 1000*60*60*24);
 	}
 	
 	class StatisticsTask extends TimerTask{


### PR DESCRIPTION
Fixes #314

#### Local Checklist
- [ ] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
Disabled CIL ingest that is on hold for new release.

##### Why are we doing this? Any context of related work?
References #314
Support for CIL ingest is on hold under the implementation of CIL API for source json files retrieval.

#### Where should a reviewer start?

#### Manual testing steps?

#### Screenshots

---

#### Database changes

#### New ENV variables
References #issuenumber

#### Deployment Instructions

@ucsdlib/developers - please review
