### PR TITLE
Fixes #332 - Support PDF and image watermarking in Excel InputStream tool

### DIFF
--- a/WebContent/WEB-INF/jsp/excelImport.jsp
+++ b/WebContent/WEB-INF/jsp/excelImport.jsp
@@ -156,6 +156,25 @@
 			else
 				$(this).attr('disabled', false);
 		});
+
+		var watermarkingOpt = $('input[name="watermarking"]');
+		if ($(obj).prop('checked')) {
+			watermarkingOpt.attr('disabled', false);
+			watermarkingOpt.attr('checked', false);
+		} else {
+			watermarkingOpt.attr('disabled', true);
+		}
+	}
+
+	function onWatermarkingSelectionChange(obj) {
+		var watermarkingOpt = $('input[name="watermarking"]');
+		if (watermarkingOpt.prop('checked')) {
+			var watermarkingConfirm = confirm('Are you sure you want to generate watermarked document and image service files?');
+
+			if(!watermarkingConfirm) {
+				watermarkingOpt.attr('checked', false);
+			}
+		}
 	}
 
 	function selectCollection(selectObj){
@@ -445,6 +464,14 @@
 				</div>
 			    <div class="submenuText" style="margin-top:3px;padding-left:25px;"  title="Enter a filter path for the location to speek up the search. From the popup, click on the folder to select/deselect a location. Multiple loations allowed.">Master Files location: 
 					<input type="text" id="filesPath" name="filesPath" size="48" value="">&nbsp;<input type="button" onclick="showFilePicker('filesPath', event)" value="&nbsp;...&nbsp;">
+				</div>
+			</td>
+		</tr>
+		<tr align="left">
+			<td colspan="2">
+				<div title="Generate watermarked document and image service files" class="menuText">
+					<input class="pcheckbox" type="checkbox" name="watermarking" id="watermarking" onchange="onWatermarkingSelectionChange(this);" disabled>
+					<span class="submenuText" style="vertical-align:2px;"><b>Generate watermarked document and image service files</b></span>
 				</div>
 			</td>
 		</tr>

--- a/src/edu/ucsd/library/xdre/tab/ExcelSource.java
+++ b/src/edu/ucsd/library/xdre/tab/ExcelSource.java
@@ -63,6 +63,9 @@ public class ExcelSource implements RecordSource
     private boolean validateControlFieldsOnly = false;      // flag to control either validate the control fields or ignore them.
     Map<String,String> cache;
 
+    // flag for watermarking
+    protected boolean watermarking = false;
+
     /**
      * Create an ExcelSource object from an Excel file on disk.
     **/
@@ -155,6 +158,21 @@ public class ExcelSource implements RecordSource
         }
     }
 
+    /**
+     * Get the watermarking flag
+     */
+    public boolean isWatermarking() {
+        return watermarking;
+    }
+
+    /**
+     * Set the watermarking flag
+     * @param watermarking
+     */
+    public void setWatermarking(boolean watermarking) {
+        this.watermarking = watermarking;
+    }
+
     @Override
     public Record nextRecord() throws Exception
     {
@@ -169,6 +187,8 @@ public class ExcelSource implements RecordSource
             if (cache.size() > 0) {
                 TabularRecord rec = new TabularRecord();
                 rec.setData( cache );
+                rec.setWatermarking(watermarking);
+
                 String objID = cache.get(OBJECT_ID);
                 String cmpID = null;
 
@@ -184,6 +204,8 @@ public class ExcelSource implements RecordSource
                     {
                         TabularRecord component = new TabularRecord();
                         component.setData(cmpData);
+                        component.setWatermarking(watermarking);
+
                         if (objectComponentType.equalsIgnoreCase(COMPONENT)) {
                             // component record, add to list
                             rec.addComponent( component );
@@ -212,6 +234,8 @@ public class ExcelSource implements RecordSource
         else if ( cache != null && cache.size() > 0)
         {
             TabularRecord rec = new TabularRecord(cache);
+            rec.setWatermarking(watermarking);
+
             cache = null;
             return rec;
         }

--- a/src/edu/ucsd/library/xdre/tab/TabularRecord.java
+++ b/src/edu/ucsd/library/xdre/tab/TabularRecord.java
@@ -19,6 +19,7 @@ import org.dom4j.Element;
 import org.dom4j.Namespace;
 import org.dom4j.QName;
 
+import edu.ucsd.library.xdre.collection.CollectionHandler;
 
 /**
  * A bundle of tabular data, consisting of a key-value map for the record, and 0 or more
@@ -59,6 +60,9 @@ public class TabularRecord implements Record
     private int counter = 0;
     private int cmpCounter = 0;
 
+    // flag for watermarking
+    private boolean watermarking = false;
+
     /**
      * Create an empty record.
     **/
@@ -82,6 +86,21 @@ public class TabularRecord implements Record
     {
         this.data = (data != null) ? data : new HashMap<String,String>();
         this.cmp = (cmp != null) ? cmp : new ArrayList<TabularRecord>();
+    }
+
+    /**
+     * Get the watermarking flag
+     */
+    public boolean isWatermarking() {
+        return watermarking;
+    }
+
+    /**
+     * Set the watermarking flag
+     * @param watermarking
+     */
+    public void setWatermarking(boolean watermarking) {
+        this.watermarking = watermarking;
     }
 
     /**
@@ -428,7 +447,14 @@ public class TabularRecord implements Record
         String use = data.get("file use");
         if ( pop(fn) )
         {
-        	addFile (e, fileID, fn, use);
+            String file1Id = fileID;
+            if (watermarking && CollectionHandler.isDocument(fn, use)
+                    && use.toLowerCase().contains("source")) {
+                // PDF source file that need watermarking will be stored as the second file
+                file1Id = getSecondFileID (fileID);
+            }
+
+            addFile (e, file1Id, fn, use);
         }
         
         fn = data.get("file name 2");

--- a/src/edu/ucsd/library/xdre/utils/Constants.java
+++ b/src/edu/ucsd/library/xdre/utils/Constants.java
@@ -66,7 +66,10 @@ public class Constants {
 	public static String ZOOMIFY_COMMAND = "";
 
 	public static String WATERMARK_COMMAND = "";
+	//path to the image watermark file used for watermarking
 	public static String WATERMARK_IMAGE = "";
+	//derivative name/use pairs for watermarking
+	public static Map<String, String> WATERMARKED_DERIVATIVES = null;
 
 	/* begin stats declaration*/
 	public static String CURATOR_ROLE ="";
@@ -201,6 +204,16 @@ public class Constants {
 			WATERMARK_COMMAND = props.getProperty("watermark.command");
 			//Watermark image file
 			WATERMARK_IMAGE = props.getProperty("watermark.image");
+			//Derivative name/use pairs for watermarking
+			WATERMARKED_DERIVATIVES = new HashMap<>();
+			String derivativeList = props.getProperty("watermark.derivative.list");
+			if (derivativeList != null) {
+				String[] ders = derivativeList.split(",");
+				for (String der : ders) {
+					String[] pair = der.split("\\:");
+					WATERMARKED_DERIVATIVES.put(pair[0].trim(), pair[1].trim());
+				}
+			}
 
 			// Namespace prefix
 			NS_PREFIX = props.getProperty("ns.prefix");

--- a/src/edu/ucsd/library/xdre/utils/ImageWatermarking.java
+++ b/src/edu/ucsd/library/xdre/utils/ImageWatermarking.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 
 import javax.imageio.ImageIO;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Interface to create watermarked image with convert command through ImageMagick.
  * @author lsitu@ucsd.edu
@@ -38,9 +40,24 @@ public class ImageWatermarking extends Watermarking
      */
     public boolean createWatermarkedDerivative( String src, String dst ) throws Exception
     {
-        // retrieve the default image watermark from source code
-        String watermark = defaultImageWatermark();
-        return createWatermarkedDerivative(src, dst, watermark);
+        return createWatermarkedDerivative(src, dst, null);
+    }
+
+    /**
+     * Create watermarked derivative
+     * @param oid
+     * @param cid
+     * @param sfid source file id
+     * @param dfid destination file id of the watermarking derivative
+     * @return the watermarked file created
+     * @throws Exception
+     */
+    public File createWatermarkedDerivative( String oid, String cid, String sfid, String dfid ) throws Exception
+    {
+        File srcFile = localArkFile(oid, cid, sfid);
+        File dstFile = watermarkFile(oid, cid, dfid);
+        createWatermarkedDerivative( srcFile.getAbsolutePath(), dstFile.getAbsolutePath(), Constants.WATERMARK_IMAGE );
+        return dstFile;
     }
 
     /**
@@ -55,6 +72,11 @@ public class ImageWatermarking extends Watermarking
     public boolean createWatermarkedDerivative( String src, String dst, String watermark )
             throws Exception
     {
+        // retrieve the default image watermark from source code when no image watermark provided
+        if (StringUtils.isBlank(watermark)) {
+            watermark = defaultImageWatermark();
+        }
+
         // build the command
         ArrayList<String> cmd = new ArrayList<String>();
         cmd.add( command );

--- a/src/edu/ucsd/library/xdre/utils/Watermarking.java
+++ b/src/edu/ucsd/library/xdre/utils/Watermarking.java
@@ -1,6 +1,7 @@
 package edu.ucsd.library.xdre.utils;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 
 /**
@@ -36,6 +37,23 @@ public class Watermarking extends ProcessBasic
     }
 
     /**
+     * Create watermarked derivative
+     * @param oid
+     * @param cid
+     * @param sfid source file id
+     * @param dfid destination file id of the watermarking derivative
+     * @return the watermarked file created
+     * @throws Exception
+     */
+    public File createWatermarkedDerivative( String oid, String cid, String sfid, String dfid ) throws Exception
+    {
+        File srcFile = localArkFile(oid, cid, sfid);
+        File dstFile = watermarkFile(oid, cid, dfid);
+        createWatermarkedDerivative( srcFile.getAbsolutePath(), dstFile.getAbsolutePath() );
+        return dstFile;
+    }
+
+    /**
      * Generate watermarked derivative
     * @param src
      * @param dst
@@ -63,5 +81,43 @@ public class Watermarking extends ProcessBasic
         if(!tmpDir.exists()){
             tmpDir.mkdirs();
         }
+    }
+
+    /**
+     * Construct the local file in filestore
+     * @param oid
+     * @param cid
+     * @param fid
+     * @return
+     */
+    protected File localArkFile(String oid, String cid, String fid) {
+        // Local file support only
+        String ark = DAMSClient.stripID(oid);
+        String fsDir = Constants.FILESTORE_DIR+ "/" + DAMSClient.pairPath(ark);
+        String fName = Constants.ARK_ORG + "-" + ark + "-" + (cid==null||cid.length()==0?"0-":cid+"-") + fid;
+        return new File(fsDir, fName);
+    }
+
+    /**
+     * Create temporary file for watermarking
+     * @param oid
+     * @param cid
+     * @param fid
+     * @return
+     * @throws IOException 
+     */
+    protected File watermarkFile(String oid, String cid, String fid) throws IOException {
+        String ark = DAMSClient.stripID(oid);
+        String fName = Constants.ARK_ORG + "-" + ark + "-" + (cid==null||cid.length()==0?"0-":cid+"-") + fid;
+        File tmpDir = new File(Constants.DAMS_STAGING + WATERMARK_LOCATION);
+
+        File watermarkedFile = File.createTempFile("watermarked", "-" + fName, tmpDir);
+        if (watermarkedFile.exists()) {
+            // delete the watermared file if it exists to avoid complains.
+            watermarkedFile.delete();
+        }
+
+        watermarkedFile.deleteOnExit();
+        return watermarkedFile;
     }
 }

--- a/src/edu/ucsd/library/xdre/web/CollectionOperationController.java
+++ b/src/edu/ucsd/library/xdre/web/CollectionOperationController.java
@@ -597,7 +597,8 @@ public class CollectionOperationController implements Controller {
 				  boolean collectionImport = getParameter(paramsMap, "collectionImport") != null;
 				  boolean preprocessing = importOption == null;
 				  boolean filesCheck = preingestOption != null && preingestOption.startsWith("file-");
-				  
+				  boolean watermarking = getParameter(paramsMap, "watermarking") != null;
+
 				  List<String> ingestFiles = new ArrayList<String>();
 				  if (preprocessing)
 					  filesPaths = filesCheckPaths;  
@@ -699,6 +700,7 @@ public class CollectionOperationController implements Controller {
 
 								  // Handling Excel Input Stream records
 								  recordSource = new ExcelSource((File)srcRecord, ignoredFields);
+								  ((ExcelSource)recordSource).setWatermarking(watermarking);
 
 								  // Report for Excel column name validation
 								  List<String> invalidColumns = ((ExcelSource)recordSource).getInvalidColumns();
@@ -1081,6 +1083,7 @@ public class CollectionOperationController implements Controller {
 								  handler = new RDFDAMS4ImportTsHandler(damsClient, dataFiles.toArray(new File[dataFiles.size()]), importOption);
 								  ((RDFDAMS4ImportTsHandler)handler).setFilesPaths(ingestFiles.toArray(new String[ingestFiles.size()]));
 								  ((RDFDAMS4ImportTsHandler)handler).setReplace(true);
+								  ((RDFDAMS4ImportTsHandler)handler).setWatermarking(watermarking);
 								  handler.setCollectionId(collectionId);
 								  if (StringUtils.isNotBlank(warnings))
 									  handler.addWarning(warnings);


### PR DESCRIPTION
Fixes #332

#### Local Checklist
- [ ] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [x] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
Add option Excel InputStream tool to support PDF and image watermarking during ingest. 
Notes:
-  To make it consistent with the current support in dams, PDF source (document-source) stored as 2.pdf and the watermarked PDF (document-service) created as 1.pdf.
- Watermarked image/derivative only created for image-huge, image-large, image-service, and image-preview.
- Zoomify tiles are create with the image-huge derivative (7.jpg).

##### Why are we doing this? Any context of related work?
References #332, #331, #320 

#### Where should a reviewer start?

#### Manual testing steps?

#### Screenshots
<img width="992" alt="Screen Shot 2019-06-20 at 1 19 25 PM" src="https://user-images.githubusercontent.com/2430784/59949474-01b8c600-9428-11e9-8187-465825ba96fe.png">
<img width="1009" alt="Screen Shot 2019-06-20 at 1 20 29 PM" src="https://user-images.githubusercontent.com/2430784/59949473-01b8c600-9428-11e9-9c57-7aeddc9fa3ca.png">
<img width="1046" alt="Screen Shot 2019-06-20 at 1 18 29 PM" src="https://user-images.githubusercontent.com/2430784/59949475-02515c80-9428-11e9-94f4-1422a3d3bbb4.png">

---

#### Database changes

#### New ENV variables
References #issuenumber

#### Deployment Instructions

@mcritchlow / @ucsdlib/developers - please review
