### PR TITLE
Fixes #317 - Add spaces surrounding pipe as multi-values delimiter

### DIFF
--- a/src/edu/ucsd/library/xdre/tab/RDFExcelConvertor.java
+++ b/src/edu/ucsd/library/xdre/tab/RDFExcelConvertor.java
@@ -351,9 +351,13 @@ public class RDFExcelConvertor {
 		}
 	}
 
-	private void appendValues(StringBuilder line, int fieldCount, String fieldValues, boolean mutiValuesField) {
+	private void appendValues(StringBuilder line, int fieldCount, String fieldValues, boolean multiValuesField) {
 		if (StringUtils.isNotBlank(fieldValues)) {
-			String[] values = mutiValuesField ? new String[] { fieldValues } : fieldValues.split("\\|");
+			String[] values = fieldValues.split("\\" + TabularRecord.DELIMITER);
+			if (multiValuesField) {
+				String strVal = concatValues(values, " " + TabularRecord.DELIMITER + " ");
+				values = new String[]{ strVal };
+			}
 
 			Arrays.sort(values);
 			for (String value : values) {
@@ -364,7 +368,7 @@ public class RDFExcelConvertor {
 			}
 
 			// append commas for extra fields
-			if (!mutiValuesField && fieldCount > values.length) {
+			if (!multiValuesField && fieldCount > values.length) {
 				for (int i= values.length; i< fieldCount; i++) {
 					line.append(",");
 				}
@@ -373,6 +377,22 @@ public class RDFExcelConvertor {
 			for(int i=0; i<fieldCount; i++)
 				line.append(",");
 		}
+	}
+
+	/*
+	 * Join array elements into string with delimiter.
+	 * @param values
+	 * @param delimiter
+	 * @return
+	 */
+	private static String concatValues(String[] values, String delimiter) {
+	    StringBuilder builder = new StringBuilder();
+	    for (String v : values) {
+	        if (builder.length() > 0)
+	            builder.append(delimiter);
+	        builder.append(v);
+	    }
+	    return builder.toString();
 	}
 
 	private void appendFlatColumnNames(StringBuilder line, int fieldCount, String columnName) {

--- a/test/edu/ucsd/library/xdre/harvesting/CilHavestingTest.java
+++ b/test/edu/ucsd/library/xdre/harvesting/CilHavestingTest.java
@@ -273,9 +273,9 @@ public class CilHavestingTest extends CilHavestingTestBase {
 
     @Test
     public void testCsvExportWithMultiValues() throws Exception {
-        String personResearsher = "\"W. Stoeckenius|Wolfgang Bettighofer|Buchanan, JoAnn|Richard Allen\"";
-        String subjectAnatomy = "artificial phospholipid membrane|membrane";
-        String subjectTopic = "free text for response to chemical stimulus|response to chemical stimulus";
+        String personResearsher = "\"W. Stoeckenius | Wolfgang Bettighofer | Buchanan, JoAnn | Richard Allen\"";
+        String subjectAnatomy = "artificial phospholipid membrane | membrane";
+        String subjectTopic = "free text for response to chemical stimulus | response to chemical stimulus";
 
         String[] files = {createJsonDataFile("test123.json").getAbsolutePath()};
         CilHarvesting cilHarvesting = new CilHarvesting(fieldMappings, constantFields, Arrays.asList(files));


### PR DESCRIPTION
References #317

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
Surrounding pipe with spaces as the delimiter for multi-values fields.

##### Why are we doing this? Any context of related work?
References #317

#### Where should a reviewer start?

#### Manual testing steps?

#### Screenshots

---

#### Database changes

#### New ENV variables
References #issuenumber

#### Deployment Instructions

@mcritchlow / @ucsdlib/developers - please review
